### PR TITLE
Pin fastmcp version to 2.2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncmy>=0.2.10",
-    "fastmcp[cli]>=2.2.8",
+    "fastmcp[cli]==2.2.8",
     "google-genai>=1.15.0",
     "google-generativeai>=0.8.5",
     "openai>=1.78.1",


### PR DESCRIPTION
This prevents build errors with newer versions of fastmcp.