### PR TITLE
Use uv.lock via compile + sync for reproducible installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,10 @@ HF_MODEL="BAAI/bge-m3"
    ```
 3. **Install dependencies**
    ```bash
-   uv pip sync
+   uv pip compile pyproject.toml -o uv.lock
+   ```
+   ```bash
+   uv pip sync uv.lock
    ```
 4. **Create `.env`** in the project root (see [Configuration](#configuration--environment-variables))
 5. **Run the server**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncmy>=0.2.10",
-    "fastmcp[cli]>=2.2.8",
+    "fastmcp[cli]==2.2.8",
     "google-genai>=1.15.0",
     "google-generativeai>=0.8.5",
     "openai>=1.78.1",


### PR DESCRIPTION
Replace `uv pip sync` with explicit compile + sync steps

- Replaces `uv pip sync` with two-step process:
  1. `uv pip compile pyproject.toml -o uv.lock`
  2. `uv pip sync uv.lock`
- Enables explicit lockfile generation and reproducible dependency management