### PR TITLE
Add `get_table_schema_with_relations` tool for enhanced AI-driven database interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The MCP MariaDB Server exposes a set of tools for interacting with MariaDB datab
   - Retrieves schema for a table (columns, types, keys, etc.).
   - Parameters: `database_name` (string, required), `table_name` (string, required)
 
+- **get_table_schema_with_relations**
+  - Retrieves schema with foreign key relations for a table.
+  - Parameters: `database_name` (string, required), `table_name` (string, required)
+
 - **execute_sql**
   - Executes a read-only SQL query (`SELECT`, `SHOW`, `DESCRIBE`).
   - Parameters: `sql_query` (string, required), `database_name` (string, optional), `parameters` (list, optional)


### PR DESCRIPTION
**This PR was made from #12**

## Problem

AI assistants cannot generate accurate JOIN queries because the current `get_table_schema` tool lacks foreign key relationship information. This forces developers to manually provide relationship context to AI, breaking MCP's autonomous operation principle.

## Solution

Added `get_table_schema_with_relations` tool that extends basic schema information with foreign key relationships, enabling AI to autonomously understand table relationships and generate accurate JOIN queries.

## Implementation

**New Tool:**
- Extends existing `get_table_schema` functionality  
- Adds foreign key information via `information_schema` queries
- Returns structured relationship data in each column's `foreign_key` field

**Output Example:**
```json
{
  "table_name": "regions",
  "columns": {
    "region_id": {
      "type": "int(11)",
      "nullable": false,
      "key": "PRI",
      "default": null,
      "extra": "auto_increment",
      "foreign_key": null
    },
    "name": {
      "type": "varchar(100)",
      "nullable": false,
      "key": "",
      "default": null,
      "extra": "",
      "foreign_key": null
    },
    "continent_id": {
      "type": "int(11)",
      "nullable": false,
      "key": "MUL",
      "default": null,
      "extra": "",
      "foreign_key": {
        "constraint_name": "regions_ibfk_1",
        "referenced_table": "continents",
        "referenced_column": "continent_id",
        "on_update": "RESTRICT",
        "on_delete": "RESTRICT"
      }
    }
  }
}
```

## Changes
- ✅ New tool: get_table_schema_with_relations
- ✅ Zero breaking changes
- ✅ Backward compatible

## Testing
- [x] Multiple foreign keys
- [x] No foreign keys