### PR TITLE
making version 0.21.2 of tokenizers locked in project deps.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,5 +12,6 @@ dependencies = [
     "openai>=1.78.1",
     "python-dotenv>=1.1.0",
     "sentence-transformers>=4.1.0",
-    "asyncmy>=0.2.10"
+    "asyncmy>=0.2.10",
+    "tokenizers==0.21.2",
 ]


### PR DESCRIPTION
due to a new version of tokenizers==0.21.4 released hours ago, the installation fails because the pypi package didn't supply *any* of the platform binaries.

while the issue might be resolved soon, it's unknown when, and will probably will happen in the next release of tokenizers as well.

the issue might be not trivial for most people.