### PR TITLE
Add DB_CHARSET Configuration Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ All configuration is via environment variables (typically set in a `.env` file):
 | `DB_USER`              | MariaDB username                                       | Yes      |              |
 | `DB_PASSWORD`          | MariaDB password                                       | Yes      |              |
 | `DB_NAME`              | Default database (optional; can be set per query)      | No       |              |
+| `DB_CHARSET`           | Character set for database connection (e.g., `cp1251`) | No       | MariaDB default |
 | `MCP_READ_ONLY`        | Enforce read-only SQL mode (`true`/`false`)            | No       | `true`       |
 | `MCP_MAX_POOL_SIZE`    | Max DB connection pool size                            | No       | `10`         |
 | `EMBEDDING_PROVIDER`   | Embedding provider (`openai`/`gemini`/`huggingface`)   | No     |`None`(Disabled)|

--- a/src/config.py
+++ b/src/config.py
@@ -51,7 +51,7 @@ DB_PORT = int(os.getenv("DB_PORT", 3306))
 DB_USER = os.getenv("DB_USER")
 DB_PASSWORD = os.getenv("DB_PASSWORD")
 DB_NAME = os.getenv("DB_NAME")
-DB_CHARSET = os.getenv("DB_CHARSET", "utf8mb4")
+DB_CHARSET = os.getenv("DB_CHARSET")
 
 # --- MCP Server Configuration ---
 # Read-only mode

--- a/src/config.py
+++ b/src/config.py
@@ -51,6 +51,7 @@ DB_PORT = int(os.getenv("DB_PORT", 3306))
 DB_USER = os.getenv("DB_USER")
 DB_PASSWORD = os.getenv("DB_PASSWORD")
 DB_NAME = os.getenv("DB_NAME")
+DB_CHARSET = os.getenv("DB_CHARSET", "utf8mb4")
 
 # --- MCP Server Configuration ---
 # Read-only mode

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ from fastmcp import FastMCP, Context
 
 # Import configuration settings
 from config import (
-    DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME,
+    DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME, DB_CHARSET,
     MCP_READ_ONLY, MCP_MAX_POOL_SIZE, EMBEDDING_PROVIDER,
     logger
 )
@@ -71,7 +71,7 @@ class MariaDBServer:
             return
 
         try:
-            logger.info(f"Creating connection pool for {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME} (max size: {MCP_MAX_POOL_SIZE})")
+            logger.info(f"Creating connection pool for {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME} (max size: {MCP_MAX_POOL_SIZE}, charset: {DB_CHARSET})")
             self.pool = await asyncmy.create_pool(
                 host=DB_HOST,
                 port=DB_PORT,
@@ -81,7 +81,8 @@ class MariaDBServer:
                 minsize=1,
                 maxsize=MCP_MAX_POOL_SIZE,
                 autocommit=self.autocommit,
-                pool_recycle=3600
+                pool_recycle=3600,
+                charset=DB_CHARSET
             )
             logger.info("Connection pool initialized successfully.")
         except AsyncMyError as e:

--- a/src/server.py
+++ b/src/server.py
@@ -71,19 +71,25 @@ class MariaDBServer:
             return
 
         try:
-            logger.info(f"Creating connection pool for {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME} (max size: {MCP_MAX_POOL_SIZE}, charset: {DB_CHARSET})")
-            self.pool = await asyncmy.create_pool(
-                host=DB_HOST,
-                port=DB_PORT,
-                user=DB_USER,
-                password=DB_PASSWORD,
-                db=DB_NAME,
-                minsize=1,
-                maxsize=MCP_MAX_POOL_SIZE,
-                autocommit=self.autocommit,
-                pool_recycle=3600,
-                charset=DB_CHARSET
-            )
+            pool_params = {
+                "host": DB_HOST,
+                "port": DB_PORT,
+                "user": DB_USER,
+                "password": DB_PASSWORD,
+                "db": DB_NAME,
+                "minsize": 1,
+                "maxsize": MCP_MAX_POOL_SIZE,
+                "autocommit": self.autocommit,
+                "pool_recycle": 3600
+            }
+            
+            if DB_CHARSET:
+                pool_params["charset"] = DB_CHARSET
+                logger.info(f"Creating connection pool for {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME} (max size: {MCP_MAX_POOL_SIZE}, charset: {DB_CHARSET})")
+            else:
+                logger.info(f"Creating connection pool for {DB_USER}@{DB_HOST}:{DB_PORT}/{DB_NAME} (max size: {MCP_MAX_POOL_SIZE})")
+            
+            self.pool = await asyncmy.create_pool(**pool_params)
             logger.info("Connection pool initialized successfully.")
         except AsyncMyError as e:
             logger.error(f"Failed to initialize database connection pool: {e}", exc_info=True)


### PR DESCRIPTION
### Description

  This PR introduces configurable database character set support for MariaDB connections,
  allowing users to specify the character encoding used for their database connections
  through an environment variable.

###  Changes

  - feat: Added DB_CHARSET environment variable configuration
  - refactor: Improved charset handling in connection pool initialization to make it
  optional
  - docs: Updated README.md to document the new configuration option

###  Implementation Details

  1. Configuration Enhancement - Introduced DB_CHARSET as an optional environment variable
  that can be set to specify the database connection character set
  2. Connection Pool Updates - Modified the MariaDB server initialization to:
    - Conditionally include charset in connection parameters only when specified
    - Enhanced logging to clearly indicate whether a charset is configured
  3. Documentation - Added the new configuration option to the README for user reference

###  Benefits

  - Provides flexibility for users working with databases that require specific character
  encodings
  - Maintains backward compatibility by making the charset optional (no default enforced)
  - Improves transparency through enhanced logging

###  Testing

  The changes have been tested with:
  - Connection without DB_CHARSET specified (charset omitted from connection)
  - Connection with DB_CHARSET set to a value: cp1251

###  Breaking Changes

  None - this is a backward-compatible enhancement.