### PR TITLE
Add MCP Prompts Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ A vector store table has the following columns:
 - `embedding`: VECTOR type (indexed for similarity search)
 - `metadata`: JSON (optional metadata)
 
+## Available Prompts
+
+- **explain_table**
+  - Provides a detailed explanation of a database table's structure, relationships, and usage.
+  - Parameters: `table_name` (string, required)
+
+- **query_tuning**
+  - Analyzes a SQL query for performance optimization opportunities.
+  - Parameters: `original_query` (string, required)
+
 ---
 
 ## Configuration & Environment Variables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncmy>=0.2.10",
-    "fastmcp[cli]==2.2.8",
+    "fastmcp[cli]==2.11.3",
     "google-genai>=1.15.0",
     "google-generativeai>=0.8.5",
     "openai>=1.78.1",

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -1,0 +1,103 @@
+"""
+Prompt template collection for MariaDB MCP Server
+
+This module provides various prompt templates for database analysis and optimization.
+"""
+
+def get_explain_table_prompt(table_name: str) -> str:
+    """
+    Returns a prompt template for table structure analysis.
+    
+    Args:
+        table_name: Name of the table to analyze
+        
+    Returns:
+        Formatted prompt string
+    """
+    return f"""Using DB MCP, analyze the schema and relationships of the {table_name} table in the database,
+and create documentation in an easy-to-read Markdown format.
+Before proceeding with this task, call List_databases to confirm which database to work with.
+If backend code exists in the user's codebase, please reference it to explain the role of this table.
+
+### Output Format (Markdown) (Write in the following format)
+
+# 📋 Table Analysis: {table_name}
+
+## 1. Table Overview
+- **Name**: {table_name}
+- **Type**: General
+- **Role**: Store billing details and manage payment status
+
+## 2. Column Analysis
+| Column Name     | Type         | PK/FK | NULL Allowed | Default | Description |
+|----------------|--------------|-------|--------------|---------|-------------|
+| id             | BIGINT       | PK    | NO           | -       | Unique identifier |
+| member_id      | BIGINT       | FK    | NO           | -       | Member ID (member.id) |
+| amount         | DECIMAL(10,2)|       | NO           | 0.00    | Billing amount |
+| status         | TINYINT      |       | NO           | 0       | Payment status (0:pending, 1:completed, 2:cancelled) |
+...
+
+## 3. Relationship Analysis
+### Parent Tables
+- member (member_id) → ON DELETE CASCADE / ON UPDATE CASCADE, billing target member information
+
+### Child Tables
+- payment (charge_id) → payment history reference
+
+## 4. Key Indexes
+- PK Index: PRIMARY KEY (id)
+- Secondary Index: idx_member_id (member_id) → improve performance for member-based queries"""
+
+def get_query_tuning_prompt(original_query: str) -> str:
+    """
+    Returns a prompt template for query performance analysis.
+    
+    Args:
+        original_query: Original query to analyze
+        database_name: Database name
+        optimization_focus: Optimization focus area
+        
+    Returns:
+        Formatted prompt string
+    """
+    return f"""You are a MariaDB/MySQL query performance optimization expert (DBA).  
+Using MariaDB MCP, provide **execution plan analysis, bottleneck causes, and specific improvement suggestions** for the query below.
+Before proceeding with this task, call List_databases to confirm which database to work with.
+
+---
+
+### Target Query for Analysis
+```sql
+{original_query}
+```
+
+### 1. Execution Plan Analysis
+- Interpret each column (type, rows, key, Extra) based on EXPLAIN
+- Specifically identify bottleneck sections and causes (full scan, filesort, temporary tables, etc.)
+- Explain potential impacts in large table environments
+
+### 2. Optimization Suggestions
+- Remove unnecessary operations/conditions
+- Suggest appropriate index creation SQL
+- Improve JOIN, WHERE, GROUP BY, ORDER BY structure
+- Assess feasibility of converting subqueries to JOINs
+- Propose LIMIT or data range limitation methods
+- If there are specific columns that absolutely need index settings, you may suggest them
+- Before making suggestions, make sure to execute the improved query to confirm there are no issues
+
+### 3. Improved Query Example
+- Maintain same results as original
+- Present improved query that can expect performance enhancement
+
+```sql
+[Improved Query]
+```
+
+### 4. Expected Performance Impact
+- Expected execution time change
+- Change in number of rows examined
+- Change in index usage
+
+*Output format must follow the above structure (Analysis → Suggestions → Improved Query → Impact),
+use concise technical terms and explanations that both DBAs and developers can understand.*
+"""


### PR DESCRIPTION
# Summary
1. Adds MCP prompts for common repetitive database analysis questions
2. Combined redundant get_table_schema functions into single comprehensive function

# Key Changes

## MCP Prompts Implementation
- `explain_table` prompt: Provides optimized prompt for common table analysis questions
- `query_tuning` prompt: Provides optimized prompt for frequent SQL optimization requests  
- Both prompts deliver more efficient results through structured, targeted prompting

## Schema Function Consolidation
- Combined `get_table_schema` and `get_table_schema_with_relations` into single `get_table_schema`
- Eliminated functional redundancy since one function was subset of the other
- Unified function provides comprehensive schema analysis with optional foreign key details
- Added `explain_query` tool for execution plan analysis

## Technical Improvements
- Updated to FastMCP 2.11.3 with proper tool registration
- **Fixed tool registration**: FastMCP version update requires `FunctionTool.from_function()` for class method registration
- Backward compatible, no breaking changes
- Cleaner API surface with reduced function duplication

# Why This Matters
Eliminates repetitive prompt engineering for common database questions and reduces API complexity by consolidating overlapping functionality. FastMCP update ensures proper tool registration compatibility.