### PR TITLE
Update FastMCP and add streamable-http support

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ MCP_MAX_POOL_SIZE=10
 {
   "servers": {
     "mariadb-mcp-server": {
-      "url": "http://{host}:9001",
+      "url": "http://{host}:9001/sse",
       "type": "sse"
     }
   }

--- a/README.md
+++ b/README.md
@@ -215,12 +215,6 @@ MCP_MAX_POOL_SIZE=10
    ```bash
    python server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp
    ```
-   
-   **HTTPS Transport (with SSL certificates):**
-   ```bash
-   python server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp \
-     --ssl-keyfile /path/to/key.pem --ssl-certfile /path/to/cert.pem
-   ```
 
 ---
 
@@ -314,7 +308,7 @@ MCP_MAX_POOL_SIZE=10
 }
 ```
 
-### Option 3: HTTP Transport (Recommended for production)
+### Option 3: HTTP Transport
 ```json
 {
   "servers": {
@@ -326,17 +320,6 @@ MCP_MAX_POOL_SIZE=10
 }
 ```
 
-### Option 4: HTTPS Transport (Secure)
-```json
-{
-  "servers": {
-    "mariadb-mcp-server": {
-      "url": "https://{host}:9001/mcp",
-      "type": "streamable-http"
-    }
-  }
-}
-```
 ---
 
 ## Logging

--- a/README.md
+++ b/README.md
@@ -200,10 +200,27 @@ MCP_MAX_POOL_SIZE=10
    ```
 4. **Create `.env`** in the project root (see [Configuration](#configuration--environment-variables))
 5. **Run the server**
+   
+   **Standard Input/Output (default):**
    ```bash
    python server.py
    ```
-   _Adjust entry point if needed (e.g., `main.py`)_
+   
+   **SSE Transport:**
+   ```bash
+   python server.py --transport sse --host 127.0.0.1 --port 9001
+   ```
+   
+   **HTTP Transport (streamable HTTP):**
+   ```bash
+   python server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp
+   ```
+   
+   **HTTPS Transport (with SSL certificates):**
+   ```bash
+   python server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp \
+     --ssl-keyfile /path/to/key.pem --ssl-certfile /path/to/cert.pem
+   ```
 
 ---
 
@@ -267,6 +284,7 @@ MCP_MAX_POOL_SIZE=10
 
 ## Integration - Claude desktop/Cursor/Windsurf/VSCode
 
+### Option 1: Direct Command (stdio)
 ```json
 {
   "mcpServers": {
@@ -283,14 +301,38 @@ MCP_MAX_POOL_SIZE=10
   }
 }
 ```
-or
-**If already running MCP server**
+
+### Option 2: SSE Transport
 ```json
 {
   "servers": {
     "mariadb-mcp-server": {
-      "url": "http://{host}:9001/sse",
+      "url": "http://{host}:9001",
       "type": "sse"
+    }
+  }
+}
+```
+
+### Option 3: HTTP Transport (Recommended for production)
+```json
+{
+  "servers": {
+    "mariadb-mcp-server": {
+      "url": "http://{host}:9001/mcp",
+      "type": "streamable-http"
+    }
+  }
+}
+```
+
+### Option 4: HTTPS Transport (Secure)
+```json
+{
+  "servers": {
+    "mariadb-mcp-server": {
+      "url": "https://{host}:9001/mcp",
+      "type": "streamable-http"
     }
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncmy>=0.2.10",
-    "fastmcp[cli]==2.2.8",
+    "fastmcp[cli]==2.12.0",
     "google-genai>=1.15.0",
     "google-generativeai>=0.8.5",
     "openai>=1.78.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mariadb-server"
-version = "0.1.0"
+version = "0.2.0"
 description = "MariaDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "mariadb-server"
 version = "0.1.0"
-description = "Add your description here"
+description = "MariaDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
@@ -12,6 +12,5 @@ dependencies = [
     "openai>=1.78.1",
     "python-dotenv>=1.1.0",
     "sentence-transformers>=4.1.0",
-    "asyncmy>=0.2.10",
     "tokenizers==0.21.2",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "asyncmy>=0.2.10",
-    "fastmcp[cli]==2.12.0",
+    "fastmcp[websockets]==2.12.0",
     "google-genai>=1.15.0",
     "google-generativeai>=0.8.5",
     "openai>=1.78.1",

--- a/src/server.py
+++ b/src/server.py
@@ -766,22 +766,69 @@ class MariaDBServer:
              logger.error("Cannot register tools: Database pool is not initialized.")
              raise RuntimeError("Database pool must be initialized before registering tools.")
 
-        self.mcp.add_tool(self.list_databases)
-        self.mcp.add_tool(self.list_tables)
-        self.mcp.add_tool(self.get_table_schema)
-        self.mcp.add_tool(self.get_table_schema_with_relations)
-        self.mcp.add_tool(self.execute_sql)
-        self.mcp.add_tool(self.create_database)
+        # For FastMCP 2.12.0, we need to use the tool decorator directly
+        # Since we can't use decorators on instance methods directly, 
+        # we'll wrap them as functions
+        @self.mcp.tool
+        async def list_databases() -> List[str]:
+            """Lists all accessible databases on the connected MariaDB server."""
+            return await self.list_databases()
+            
+        @self.mcp.tool
+        async def list_tables(database_name: str) -> List[str]:
+            """Lists all tables within the specified database."""
+            return await self.list_tables(database_name)
+            
+        @self.mcp.tool
+        async def get_table_schema(database_name: str, table_name: str) -> Dict[str, Any]:
+            """Retrieves the schema for a specific table in a database."""
+            return await self.get_table_schema(database_name, table_name)
+            
+        @self.mcp.tool
+        async def get_table_schema_with_relations(database_name: str, table_name: str) -> Dict[str, Any]:
+            """Retrieves table schema with foreign key relationship information."""
+            return await self.get_table_schema_with_relations(database_name, table_name)
+            
+        @self.mcp.tool
+        async def execute_sql(sql_query: str, database_name: str, parameters: Optional[List[Any]] = None) -> List[Dict[str, Any]]:
+            """Executes a read-only SQL query against a specified database."""
+            return await self.execute_sql(sql_query, database_name, parameters)
+            
+        @self.mcp.tool
+        async def create_database(database_name: str) -> Dict[str, Any]:
+            """Creates a new database if it doesn't exist."""
+            return await self.create_database(database_name)
+            
         if EMBEDDING_PROVIDER is not None:
-            self.mcp.add_tool(self.create_vector_store)
-            self.mcp.add_tool(self.list_vector_stores)
-            self.mcp.add_tool(self.delete_vector_store)
-            self.mcp.add_tool(self.insert_docs_vector_store)
-            self.mcp.add_tool(self.search_vector_store)
+            @self.mcp.tool
+            async def create_vector_store(database_name: str, vector_store_name: str, model_name: Optional[str] = None, distance_function: Optional[str] = None) -> dict:
+                """Creates a table which stores embeddings."""
+                return await self.create_vector_store(database_name, vector_store_name, model_name, distance_function)
+                
+            @self.mcp.tool
+            async def list_vector_stores(database_name: str) -> List[str]:
+                """Lists all vector stores in a database."""
+                return await self.list_vector_stores(database_name)
+                
+            @self.mcp.tool
+            async def delete_vector_store(database_name: str, vector_store_name: str) -> Dict[str, Any]:
+                """Deletes a vector store from the specified database."""
+                return await self.delete_vector_store(database_name, vector_store_name)
+                
+            @self.mcp.tool
+            async def insert_docs_vector_store(database_name: str, vector_store_name: str, documents: List[str], metadata: Optional[List[dict]] = None) -> dict:
+                """Insert a batch of documents into a vector store."""
+                return await self.insert_docs_vector_store(database_name, vector_store_name, documents, metadata)
+                
+            @self.mcp.tool
+            async def search_vector_store(user_query: str, database_name: str, vector_store_name: str, k: int = 7) -> list:
+                """Search a vector store for similar documents."""
+                return await self.search_vector_store(user_query, database_name, vector_store_name, k)
+                
         logger.info("Registered MCP tools explicitly.")
 
     # --- Async Main Server Logic ---
-    async def run_async_server(self, transport="stdio", host="127.0.0.1", port=9001):
+    async def run_async_server(self, transport="stdio", host="127.0.0.1", port=9001, path="/mcp", ssl_keyfile=None, ssl_certfile=None):
         """
         Initializes pool, registers tools, and runs the appropriate async MCP listener.
         This method should be the target for anyio.run().
@@ -798,6 +845,17 @@ class MariaDBServer:
             if transport == "sse":
                 transport_kwargs = {"host": host, "port": port}
                 logger.info(f"Starting MCP server via {transport} on {host}:{port}...")
+            elif transport == "http":
+                transport_kwargs = {"host": host, "port": port, "path": path}
+                if ssl_keyfile and ssl_certfile:
+                    # SSL parameters need to be passed through uvicorn_config
+                    transport_kwargs["uvicorn_config"] = {
+                        "ssl_keyfile": ssl_keyfile,
+                        "ssl_certfile": ssl_certfile
+                    }
+                    logger.info(f"Starting MCP server via {transport} with HTTPS on {host}:{port}{path}...")
+                else:
+                    logger.info(f"Starting MCP server via {transport} on {host}:{port}{path}...")
             elif transport == "stdio":
                  logger.info(f"Starting MCP server via {transport}...")
             else:
@@ -820,12 +878,18 @@ class MariaDBServer:
 # --- Main Execution Block ---
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="MariaDB MCP Server")
-    parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse'],
-                        help='MCP transport protocol (stdio or sse)')
+    parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse', 'http'],
+                        help='MCP transport protocol (stdio, sse, or http)')
     parser.add_argument('--host', type=str, default='127.0.0.1',
                         help='Host for SSE transport')
     parser.add_argument('--port', type=int, default=9001,
-                        help='Port for SSE transport')
+                        help='Port for SSE or HTTP transport')
+    parser.add_argument('--path', type=str, default='/mcp',
+                        help='Path for HTTP transport (default: /mcp)')
+    parser.add_argument('--ssl-keyfile', type=str, default=None,
+                        help='SSL key file for HTTPS')
+    parser.add_argument('--ssl-certfile', type=str, default=None,
+                        help='SSL certificate file for HTTPS')
     args = parser.parse_args()
 
     # 1. Create the server instance
@@ -835,7 +899,13 @@ if __name__ == "__main__":
     try:
         # 2. Use anyio.run to manage the event loop and call the main async server logic
         anyio.run(
-            partial(server.run_async_server, transport=args.transport, host=args.host, port=args.port)
+            partial(server.run_async_server, 
+                    transport=args.transport, 
+                    host=args.host, 
+                    port=args.port, 
+                    path=args.path,
+                    ssl_keyfile=args.ssl_keyfile,
+                    ssl_certfile=args.ssl_certfile)
         )
         logger.info("Server finished gracefully.")
 

--- a/src/server.py
+++ b/src/server.py
@@ -766,9 +766,6 @@ class MariaDBServer:
              logger.error("Cannot register tools: Database pool is not initialized.")
              raise RuntimeError("Database pool must be initialized before registering tools.")
 
-        # For FastMCP 2.12.0, we need to use the tool decorator directly
-        # Since we can't use decorators on instance methods directly, 
-        # we'll wrap them as functions
         @self.mcp.tool
         async def list_databases() -> List[str]:
             """Lists all accessible databases on the connected MariaDB server."""

--- a/src/server.py
+++ b/src/server.py
@@ -828,7 +828,7 @@ class MariaDBServer:
         logger.info("Registered MCP tools explicitly.")
 
     # --- Async Main Server Logic ---
-    async def run_async_server(self, transport="stdio", host="127.0.0.1", port=9001, path="/mcp", ssl_keyfile=None, ssl_certfile=None):
+    async def run_async_server(self, transport="stdio", host="127.0.0.1", port=9001, path="/mcp"):
         """
         Initializes pool, registers tools, and runs the appropriate async MCP listener.
         This method should be the target for anyio.run().
@@ -847,15 +847,7 @@ class MariaDBServer:
                 logger.info(f"Starting MCP server via {transport} on {host}:{port}...")
             elif transport == "http":
                 transport_kwargs = {"host": host, "port": port, "path": path}
-                if ssl_keyfile and ssl_certfile:
-                    # SSL parameters need to be passed through uvicorn_config
-                    transport_kwargs["uvicorn_config"] = {
-                        "ssl_keyfile": ssl_keyfile,
-                        "ssl_certfile": ssl_certfile
-                    }
-                    logger.info(f"Starting MCP server via {transport} with HTTPS on {host}:{port}{path}...")
-                else:
-                    logger.info(f"Starting MCP server via {transport} on {host}:{port}{path}...")
+                logger.info(f"Starting MCP server via {transport} on {host}:{port}{path}...")
             elif transport == "stdio":
                  logger.info(f"Starting MCP server via {transport}...")
             else:
@@ -886,10 +878,6 @@ if __name__ == "__main__":
                         help='Port for SSE or HTTP transport')
     parser.add_argument('--path', type=str, default='/mcp',
                         help='Path for HTTP transport (default: /mcp)')
-    parser.add_argument('--ssl-keyfile', type=str, default=None,
-                        help='SSL key file for HTTPS')
-    parser.add_argument('--ssl-certfile', type=str, default=None,
-                        help='SSL certificate file for HTTPS')
     args = parser.parse_args()
 
     # 1. Create the server instance
@@ -903,9 +891,7 @@ if __name__ == "__main__":
                     transport=args.transport, 
                     host=args.host, 
                     port=args.port, 
-                    path=args.path,
-                    ssl_keyfile=args.ssl_keyfile,
-                    ssl_certfile=args.ssl_certfile)
+                    path=args.path)
         )
         logger.info("Server finished gracefully.")
 

--- a/src/server.py
+++ b/src/server.py
@@ -870,7 +870,7 @@ if __name__ == "__main__":
     parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse', 'http'],
                         help='MCP transport protocol (stdio, sse, or http)')
     parser.add_argument('--host', type=str, default='127.0.0.1',
-                        help='Host for SSE transport')
+                        help='Host for SSE or HTTP transport')
     parser.add_argument('--port', type=int, default=9001,
                         help='Port for SSE or HTTP transport')
     parser.add_argument('--path', type=str, default='/mcp',


### PR DESCRIPTION
* Updates FastMCP to 2.12.0
	* For latest versions of FastMCP, we need to use the tool decorator directly since you can't use decorators on instance methods directly, wrap them as functions
* Adds streamable-http support

Known issue: the latest websockets library throws a deprecation warning: https://github.com/jlowin/fastmcp/issues/1166