### PR TITLE
Improved config and pool initialization to allow empty password.

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -82,8 +82,10 @@ HF_MODEL = os.getenv("HF_MODEL")
 
 
 # --- Validation ---
-if not all([DB_USER, DB_PASSWORD]):
-    logger.error("Database credentials (DB_USER, DB_PASSWORD) not found in environment variables or .env file.")
+if not DB_USER:
+    logger.error("DB_USER is empty or missing from the environment or .env file.")
+if DB_PASSWORD is None:
+    logger.error("DB_PASSWORD is missing from the environment or .env file.")
 
 # Embedding Provider and Keys
 logger.info(f"Selected Embedding Provider: {EMBEDDING_PROVIDER}")

--- a/src/server.py
+++ b/src/server.py
@@ -68,9 +68,12 @@ class MariaDBServer:
 
     async def initialize_pool(self):
         """Initializes the asyncmy connection pool within the running event loop."""
-        if not all([DB_USER, DB_PASSWORD]):
-             logger.error("Cannot initialize pool due to missing database credentials.")
-             raise ConnectionError("Missing database credentials for pool initialization.")
+        if not DB_USER:
+            logger.error("Cannot initialize pool: DB_USER is empty or missing")
+            raise ConnectionError("Missing DB_USER for pool initialization.")
+        if DB_PASSWORD is None:
+            logger.error("Cannot initialize pool: DB_PASSWORD is missing")
+            raise ConnectionError("Missing DB_PASSWORD for pool initialization.")
 
         if self.pool is not None:
             logger.info("Connection pool already initialized.")


### PR DESCRIPTION
Improved the DB_PASSWORD environment variable validation to allow blank password. Useful if you are running a localhost database instance with no root password.