### PR TITLE
Add Ollama as an Embedding Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,13 +104,18 @@ The MCP MariaDB Server provides **optional** embedding and vector store capabili
 - **OpenAI**
 - **Gemini**
 - **Open models from Huggingface**
+- **Open models from Ollama**
 
 ### Configuration
 
-- `EMBEDDING_PROVIDER`: Set to `openai`, `gemini`, `huggingface`, or leave unset to disable
+- `EMBEDDING_PROVIDER`: Set to `openai`, `gemini`, `huggingface`, `ollama` or leave unset to disable
 - `OPENAI_API_KEY`: Required if using OpenAI embeddings
 - `GEMINI_API_KEY`: Required if using Gemini embeddings
 - `HF_MODEL`: Required if using HuggingFace embeddings (e.g., "intfloat/multilingual-e5-large-instruct" or "BAAI/bge-m3")
+- `OLLAMA_HOST`: Required if using Ollama embeddings
+- `OLLAMA_PORT`: Required if using Ollama embeddings
+- `OLLAMA_MODEL`: Required if using Ollama embeddings
+
 ### Model Selection
 
 - Default and allowed models are configurable in code (`DEFAULT_OPENAI_MODEL`, `ALLOWED_OPENAI_MODELS`)
@@ -130,22 +135,25 @@ A vector store table has the following columns:
 
 All configuration is via environment variables (typically set in a `.env` file):
 
-| Variable               | Description                                            | Required | Default      |
-|------------------------|--------------------------------------------------------|----------|--------------|
-| `DB_HOST`              | MariaDB host address                                   | Yes      | `localhost`  |
-| `DB_PORT`              | MariaDB port                                           | No       | `3306`       |
-| `DB_USER`              | MariaDB username                                       | Yes      |              |
-| `DB_PASSWORD`          | MariaDB password                                       | Yes      |              |
-| `DB_NAME`              | Default database (optional; can be set per query)      | No       |              |
-| `DB_CHARSET`           | Character set for database connection (e.g., `cp1251`) | No       | MariaDB default |
-| `MCP_READ_ONLY`        | Enforce read-only SQL mode (`true`/`false`)            | No       | `true`       |
-| `MCP_MAX_POOL_SIZE`    | Max DB connection pool size                            | No       | `10`         |
-| `EMBEDDING_PROVIDER`   | Embedding provider (`openai`/`gemini`/`huggingface`)   | No     |`None`(Disabled)|
-| `OPENAI_API_KEY`       | API key for OpenAI embeddings                          | Yes (if EMBEDDING_PROVIDER=openai) | |
-| `GEMINI_API_KEY`       | API key for Gemini embeddings                          | Yes (if EMBEDDING_PROVIDER=gemini) | |
-| `HF_MODEL`             | Open models from Huggingface                           | Yes (if EMBEDDING_PROVIDER=huggingface) | |
-| `ALLOWED_ORIGINS`      | Comma-separated list of allowed origins                | No       | Long list of allowed origins corresponding to local use of the server |
-| `ALLOWED_HOSTS`        | Comma-separated list of allowed hosts                  | No       | `localhost,127.0.0.1` |
+| Variable               | Description                                                     | Required | Default      |
+|------------------------|-----------------------------------------------------------------|----------|--------------|
+| `DB_HOST`              | MariaDB host address                                            | Yes      | `localhost`  |
+| `DB_PORT`              | MariaDB port                                                    | No       | `3306`       |
+| `DB_USER`              | MariaDB username                                                | Yes      |              |
+| `DB_PASSWORD`          | MariaDB password                                                | Yes      |              |
+| `DB_NAME`              | Default database (optional; can be set per query)               | No       |              |
+| `DB_CHARSET`           | Character set for database connection (e.g., `cp1251`)          | No       | MariaDB default |
+| `MCP_READ_ONLY`        | Enforce read-only SQL mode (`true`/`false`)                     | No       | `true`       |
+| `MCP_MAX_POOL_SIZE`    | Max DB connection pool size                                     | No       | `10`         |
+| `EMBEDDING_PROVIDER`   | Embedding provider (`openai`/`gemini`/`huggingface`/`ollama`)   | No     |`None`(Disabled)|
+| `OPENAI_API_KEY`       | API key for OpenAI embeddings                                   | Yes (if EMBEDDING_PROVIDER=openai) | |
+| `GEMINI_API_KEY`       | API key for Gemini embeddings                                   | Yes (if EMBEDDING_PROVIDER=gemini) | |
+| `HF_MODEL`             | Open models from Huggingface                                    | Yes (if EMBEDDING_PROVIDER=huggingface) | |
+| `OLLAMA_HOST`          | Ollama host address                                             | Yes (if EMBEDDING_PROVIDER=ollama) | `localhost` |
+| `OLLAMA_PORT`          | Ollama port                                                     | Yes (if EMBEDDING_PROVIDER=ollama) | `11434` |
+| `OLLAMA_MODEL`         | Open models from Ollama                                         | Yes (if EMBEDDING_PROVIDER=ollama) | |
+| `ALLOWED_ORIGINS`      | Comma-separated list of allowed origins                         | No       | Long list of allowed origins corresponding to local use of the server |
+| `ALLOWED_HOSTS`        | Comma-separated list of allowed hosts                           | No       | `localhost,127.0.0.1` |
 
 Note that if using 'http' or 'sse' as the transport, configuring authentication is important for security if you allow connections outside of localhost. Because different organizations use different authentication methods, the server does not provide a default authentication method. You will need to configure your own authentication method. Thankfully FastMCP provides a simple way to do this starting with version 2.12.1. See the [FastMCP documentation](https://gofastmcp.com/servers/auth/authentication#environment-configuration) for more information. We have provided an example configuration below.
 
@@ -166,6 +174,9 @@ EMBEDDING_PROVIDER=openai
 OPENAI_API_KEY=sk-...
 GEMINI_API_KEY=AI...
 HF_MODEL="BAAI/bge-m3"
+OLLAMA_HOST=localhost
+OLLAMA_PORT=11434
+OLLAMA_MODEL="nomic-embed-text"
 ```
 
 **Without Embedding Support:**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "asyncmy>=0.2.10",
     "fastmcp[websockets]==2.12.1",
     "google-genai>=1.15.0",
+    "ollama>=0.6.0",
     "openai>=1.78.1",
     "python-dotenv>=1.1.0",
     "sentence-transformers>=4.1.0",

--- a/src/config.py
+++ b/src/config.py
@@ -79,7 +79,10 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 # Open models from Huggingface
 HF_MODEL = os.getenv("HF_MODEL")
-
+# Ollama Configuration
+OLLAMA_HOST = os.getenv("OLLAMA_HOST", "localhost")
+OLLAMA_PORT = os.getenv("OLLAMA_PORT", 11434)
+OLLAMA_MODEL = os.getenv("OLLAMA_MODEL")
 
 # --- Validation ---
 if not all([DB_USER, DB_PASSWORD]):
@@ -99,9 +102,13 @@ elif EMBEDDING_PROVIDER == "huggingface":
     if not HF_MODEL:
         logger.error("EMBEDDING_PROVIDER is 'huggingface' but HF_MODEL is missing.")
         raise ValueError("HuggingFace model is required when EMBEDDING_PROVIDER is 'huggingface'.")
+elif EMBEDDING_PROVIDER == "ollama":
+    if not OLLAMA_MODEL:
+        logger.error("EMBEDDING_PROVIDER is 'ollama' but OLLAMA_MODEL is missing.")
+        raise ValueError("Ollama model is required when EMBEDDING_PROVIDER is 'ollama'.")
 else:
     EMBEDDING_PROVIDER = None
-    logger.info(f"No EMBEDDING_PROVIDER selected or it is set to None. Disabling embedding features.")
+    logger.info("No EMBEDDING_PROVIDER selected or it is set to None. Disabling embedding features.")
 
 logger.info(f"Read-only mode: {MCP_READ_ONLY}")
 logger.info(f"Logging to console and to file: {LOG_FILE_PATH} (Level: {LOG_LEVEL}, MaxSize: {LOG_MAX_BYTES}B, Backups: {LOG_BACKUP_COUNT})")

--- a/src/tests/test_embedding_service.py
+++ b/src/tests/test_embedding_service.py
@@ -42,5 +42,17 @@ class TestEmbeddingServiceGemini(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(len(result), 768)
 
+class TestEmbeddingServiceOllama(unittest.TestCase):
+    @patch("embeddings.EMBEDDING_PROVIDER", "ollama")
+    def test_ollama_init_and_embed(self):
+        service = EmbeddingService()
+        self.assertEqual(service.provider, "ollama")
+        self.assertIn("nomic-embed-text", service.allowed_models)
+        self.assertEqual(service.default_model, "nomic-embed-text")
+        # Test embed
+        result = asyncio.run(service.embed("hello world"))
+        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 768)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Description
This PR introduces Ollama as an alternative embedding provider to Hugging Face, enabling local CPU/GPU embedding inference, enhancing data privacy, and reducing cloud dependency and cost. It also improves flexibility by allowing users to choose between cloud-based (Hugging Face) and self-hosted (Ollama) embedding generation. 

### Changes
- Added ollama client dependency to pyproject.toml.
- Implemented Ollama configuration and centralized error handling in config.py.
- Added model definitions for Ollama embedding models and extended EmbeddingService to process Ollama-based embedding requests in embeddings.py.
- Introduced unit tests for Ollama integration via TestEmbeddingServiceOllama in test_embedding_service.py.
- Updated README.md with documentation on using Ollama as an embedding provider.

### Implementation Details
- Run Ollama server
- Config .env with:
   - EMBEDDING_PROVIDER=ollama
   - OLLAMA_HOST=localhost
   - OLLAMA_PORT=11434
   - OLLAMA_MODEL="nomic-embed-text" 
- uv run server.py

### Checklist
✅Code compiles successfully
✅Unit tests added and passing
✅Documentation updated
✅No breaking changes introduced