### PR TITLE
Expose FastMCP object to allow for use of FastMCP Features

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1031,8 +1031,7 @@ class MariaDBServer:
             logger.info(f"Server exiting with code {exit_code}.")
 
 
-# --- Main Execution Block ---
-if __name__ == "__main__":
+def get_arg_parser():
     parser = argparse.ArgumentParser(description="MariaDB MCP Server")
     parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse', 'http'],
                         help='MCP transport protocol (stdio, sse, or http)')
@@ -1042,7 +1041,12 @@ if __name__ == "__main__":
                         help='Port for SSE or HTTP transport')
     parser.add_argument('--path', type=str, default='/mcp',
                         help='Path for HTTP transport (default: /mcp)')
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+# --- Main Execution Block ---
+if __name__ == "__main__":
+    args = get_arg_parser()
 
     # 1. Create the server instance
     server = MariaDBServer()

--- a/src/server.py
+++ b/src/server.py
@@ -1031,7 +1031,7 @@ class MariaDBServer:
             logger.info(f"Server exiting with code {exit_code}.")
 
 
-def get_arg_parser():
+def get_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="MariaDB MCP Server")
     parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse', 'http'],
                         help='MCP transport protocol (stdio, sse, or http)')
@@ -1041,12 +1041,12 @@ def get_arg_parser():
                         help='Port for SSE or HTTP transport')
     parser.add_argument('--path', type=str, default='/mcp',
                         help='Path for HTTP transport (default: /mcp)')
-    return parser.parse_args()
+    return parser
 
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
-    args = get_arg_parser()
+    args = get_arg_parser().parse_args()
 
     # 1. Create the server instance
     server = MariaDBServer()

--- a/src/server.py
+++ b/src/server.py
@@ -1007,6 +1007,29 @@ class MariaDBServer:
         finally:
             await self.close_pool()
 
+    # Sync server start logic
+    def start(self):
+        exit_code = 0
+
+        try:
+            # 2. Use anyio.run to manage the event loop and call the main async server logic
+            anyio.run(
+                partial(self.run_async_server,
+                        transport=args.transport,
+                        host=args.host,
+                        port=args.port,
+                        path=args.path)
+            )
+            logger.info("Server finished gracefully.")
+
+        except KeyboardInterrupt:
+            logger.info("Server execution interrupted by user.")
+        except Exception as e:
+            logger.critical(f"Server failed to start or crashed: {e}", exc_info=True)
+            exit_code = 1
+        finally:
+            logger.info(f"Server exiting with code {exit_code}.")
+
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
@@ -1023,23 +1046,4 @@ if __name__ == "__main__":
 
     # 1. Create the server instance
     server = MariaDBServer()
-    exit_code = 0
-
-    try:
-        # 2. Use anyio.run to manage the event loop and call the main async server logic
-        anyio.run(
-            partial(server.run_async_server, 
-                    transport=args.transport, 
-                    host=args.host, 
-                    port=args.port, 
-                    path=args.path)
-        )
-        logger.info("Server finished gracefully.")
-
-    except KeyboardInterrupt:
-         logger.info("Server execution interrupted by user.")
-    except Exception as e:
-         logger.critical(f"Server failed to start or crashed: {e}", exc_info=True)
-         exit_code = 1
-    finally:
-        logger.info(f"Server exiting with code {exit_code}.")
+    server.start()

--- a/src/server.py
+++ b/src/server.py
@@ -1008,17 +1008,17 @@ class MariaDBServer:
             await self.close_pool()
 
     # Sync server start logic
-    def start(self):
+    def start(self, transport="stdio", host="127.0.0.1", port=9001, path="/mcp"):
         exit_code = 0
 
         try:
             # 2. Use anyio.run to manage the event loop and call the main async server logic
             anyio.run(
                 partial(self.run_async_server,
-                        transport=args.transport,
-                        host=args.host,
-                        port=args.port,
-                        path=args.path)
+                        transport=transport,
+                        host=host,
+                        port=port,
+                        path=path)
             )
             logger.info("Server finished gracefully.")
 
@@ -1046,4 +1046,4 @@ if __name__ == "__main__":
 
     # 1. Create the server instance
     server = MariaDBServer()
-    server.start()
+    server.start(args.transport, args.host, args.port, args.path)

--- a/src/tests/test_custom_resource.py
+++ b/src/tests/test_custom_resource.py
@@ -1,0 +1,51 @@
+"""
+Tests that the MariaDBServer exposes its FastMCP instance so callers can
+register additional resources before starting the server.
+
+This mirrors the pattern used by mcp_fmd_server.py, which adds a
+``schema://context`` resource to the ``mcp`` object after construction.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+import anyio
+from fastmcp.client import Client
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from server import MariaDBServer
+
+_SCHEMA_CONTENT = "# Test Schema\nThis is test schema documentation."
+
+
+class TestCustomResource(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.server = MariaDBServer()
+
+        # Register a custom resource on the exposed FastMCP instance —
+        # this is the pattern the FMD wrapper (mcp_fmd_server.py) uses.
+        @self.server.mcp.resource("schema://context")
+        def schema_context() -> str:
+            """FMD AI Schema documentation."""
+            return _SCHEMA_CONTENT
+
+    async def test_custom_resource_is_listed(self):
+        """The schema://context resource should appear in the resource list."""
+        async with Client(self.server.mcp) as client:
+            resources = await client.list_resources()
+            uris = [str(r.uri) for r in resources]
+            self.assertIn("schema://context", uris)
+
+    async def test_custom_resource_content(self):
+        """Reading schema://context should return the registered content."""
+        async with Client(self.server.mcp) as client:
+            result = await client.read_resource("schema://context")
+            # result is a list of resource content objects; grab the first text
+            text = result[0].text if result else ""
+            self.assertEqual(text, _SCHEMA_CONTENT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Purpose
The purpose of this change is to expose the `FastMCP` object contained inside `server.py` to the outside world by refactoring the startup logic in the `if __name__ == "__main__"` block.

This allows use of public features on the `FastMCP` object (e.g. [Resources](https://gofastmcp.com/servers/resources#the-@resource-decorator)) by exposing the `server.mcp` object using code such as:

```  
from server import get_arg_parser, MariaDBServer                                                                                                                            

server = MariaDBServer()

@server.mcp.resource("schema://context")                                                                                                                                    
  def schema_context() -> str:
      return Path("my_schema_context.md").read_text()                                                                                                                          
   
args = get_arg_parser().parse_args()                                                                                                                                          
server.start(args.transport, args.host, args.port, args.path)
```
The example above would allow providing a consumer with additional text-based context on the underlying MariaDB schema, which could help an LLM to make better decisions about which data to use at query time.

## Change Summary

  - Refactored server.py's startup logic out of the bare `if __name__ == "__main__"` block into two new public members:                                                           
    - `MariaDBServer.start(transport, host, port, path)` — a new, synchronous entry point that wraps `run_async_server()`
    - `get_arg_parser()` -> `ArgumentParser` — returns the CLI argument parser so callers can add their own custom args (if necessary) before parsing and passing to `start()`
  - Added `src/tests/test_custom_resource.py` — instantiates `MariaDBServer`, registers a custom `schema://context resource` on the exposed `mcp` object, then uses a `FastMCP` Client to verify the resource appears in the resource list and that its content can be read correctly

This was previously impossible since the entire server startup lifecycle was buried inside `if __name__ == "__main__"` 

                                                                                                                                                                                
# Tests
  - `test_custom_resource_is_listed` — `schema://context` appears in `list_resources()`
  - `test_custom_resource_content` — `read_resource("schema://context")` returns the expected string

# Test Results (local)
```
(mariadb-server) E:\johntest\mariadb-mcp\src\tests>python -m unittest test_custom_resource.py

2026-03-28 15:07:25,324 - config - INFO - Selected Embedding Provider: None
2026-03-28 15:07:25,324 - config - INFO - No EMBEDDING_PROVIDER selected or it is set to None. Disabling embedding features.
2026-03-28 15:07:25,324 - config - INFO - Read-only mode: True
2026-03-28 15:07:25,324 - config - INFO - Logging to console and to file: logs/mcp_server.log (Level: INFO, MaxSize: 10485760B, Backups: 5)
2026-03-28 15:07:27,908 - config - WARNING - Google Generative AI SDK ('google-genai' package) not installed. Gemini provider will not be available. Error: No module named 'google.api_core'

2026-03-28 15:07:27,910 - config - INFO - Current sys.path: ['E:\\johntest\\mariadb-mcp\\src', 'E:\\ServerFolders\\Company\\IT Dept\\johntest\\mariadb-mcp\\src\\tests', ...]
2026-03-28 15:07:27,941 - config - INFO - Initializing MariaDB_Server...
2026-03-28 15:07:27,943 - config - WARNING - Server running in READ-ONLY mode. Write operations are disabled.
2026-03-28 15:07:28,022 - mcp.server.lowlevel.server - INFO - Processing request of type ReadResourceRequest
.2026-03-28 15:07:28,043 - config - INFO - Initializing MariaDB_Server...
2026-03-28 15:07:28,043 - config - WARNING - Server running in READ-ONLY mode. Write operations are disabled.
2026-03-28 15:07:28,074 - mcp.server.lowlevel.server - INFO - Processing request of type ListResourcesRequest
.
----------------------------------------------------------------------
Ran 2 tests in 0.193s

OK

```

## In MCP Inspector:
<img width="1502" height="803" alt="Screenshot 2026-03-28 at 3 20 50 PM" src="https://github.com/user-attachments/assets/3aa3f6ff-e521-42de-a14b-aa27a7b53edf" />
