### PR TITLE
Simplify MCP setup by publishing to PyPI and adding a console entry point

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,71 @@
+name: Publish Python package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+  publish-testpypi:
+    name: Publish debug build to TestPyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
+    environment:
+      name: testpypi
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to TestPyPI via Trusted Publisher (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Publish stable build to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release' && github.event.release.prerelease == false
+    environment:
+      name: pypi
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
+
+      - name: Publish to PyPI via Trusted Publisher (OIDC)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -34,25 +34,6 @@ jobs:
           name: python-dist
           path: dist/
 
-  publish-testpypi:
-    name: Publish debug build to TestPyPI
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true
-    environment:
-      name: testpypi
-    steps:
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: python-dist
-          path: dist/
-
-      - name: Publish to TestPyPI via Trusted Publisher (OIDC)
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   publish-pypi:
     name: Publish stable build to PyPI
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -249,24 +249,7 @@ For production use, you should create a dedicated database user with minimal pri
 pip install uv
 ```
 
-### Quick Start (recommended)
-
-```bash
-uvx mariadb-mcp
-```
-
-### Run from a local checkout (development)
-
-```bash
-# from your local checkout
-# cd /path/to/mariadb-mcp
-# configure environment variables (see Configuration section above)
-uv lock
-uv sync
-uv run mariadb-mcp
-```
-
-### Codex MCP setup example
+### Add MCP to your agent CLI, e.g. Codex
 
 ```bash
 codex mcp add mariadb-mcp --env DB_HOST=localhost --env DB_PORT=3306 --env DB_USER=root --env DB_PASSWORD=1234 --env DB_NAME=myprojecttestdatabase --env MCP_READ_ONLY=true -- uvx mariadb-mcp
@@ -279,6 +262,18 @@ Example Codex config:
 command = "uvx"
 args = ["mariadb-mcp"]
 env = { DB_HOST = "localhost", DB_PORT = "3306", DB_USER = "root", DB_PASSWORD = "1234", DB_NAME = "mytestdb", MCP_READ_ONLY = "true" }
+```
+
+
+### Run from a local checkout (development)
+
+```bash
+# git clone this repo
+# cd /path/to/mariadb-mcp
+# configure environment variables (see Configuration section above)
+uv lock
+uv sync
+uv run mariadb-mcp
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -240,52 +240,46 @@ For production use, you should create a dedicated database user with minimal pri
 ### Requirements
 
 - **Python 3.11** (see `.python-version`)
-- **uv** (dependency manager; [install instructions](https://github.com/astral-sh/uv))
+- **uv** (dependency manager)
 - MariaDB server (local or remote)
 
-### Steps
+### Install `uv`
 
-1. **Install `uv`** (if not already):
-   ```bash
-   pip install uv
-   ```
-2. **Install from PyPI (recommended)**
-   ```bash
-   uv tool install mariadb-mcp
-   ```
-   Or run it without installing:
-   ```bash
-   uvx mariadb-mcp
-   ```
-3. **Alternative: local development from source**
-   - Clone the repository
-   - Install dependencies
-   ```bash
-   uv lock
-   uv sync
-   ```
-4. **Create `.env`** in the project root (see [Configuration](#configuration--environment-variables))
-5. **Run the server**
-   
-   **Standard Input/Output (default):**
-   ```bash
-   mariadb-mcp
-   ```
-   
-   **SSE Transport:**
-   ```bash
-   mariadb-mcp --transport sse --host 127.0.0.1 --port 9001
-   ```
-   
-   **HTTP Transport (streamable HTTP):**
-   ```bash
-   mariadb-mcp --transport http --host 127.0.0.1 --port 9001 --path /mcp
-   ```
+```bash
+pip install uv
+```
 
-   **Local source checkout (without installation):**
-   ```bash
-   uv run server.py
-   ```
+### Quick Start (recommended)
+
+```bash
+uvx mariadb-mcp
+```
+
+### Run from a local checkout (development)
+
+```bash
+# from your local checkout
+# cd /path/to/mariadb-mcp
+# configure environment variables (see Configuration section above)
+uv lock
+uv sync
+uv run mariadb-mcp
+```
+
+### Codex MCP setup example
+
+```bash
+codex mcp add mariadb-mcp --env DB_HOST=localhost --env DB_PORT=3306 --env DB_USER=root --env DB_PASSWORD=1234 --env DB_NAME=myprojecttestdatabase --env MCP_READ_ONLY=true -- uvx mariadb-mcp
+```
+
+Example Codex config:
+
+```toml
+[mcp_servers.mariadb-mcp]
+command = "uvx"
+args = ["mariadb-mcp"]
+env = { DB_HOST = "localhost", DB_PORT = "3306", DB_USER = "root", DB_PASSWORD = "1234", DB_NAME = "mytestdb", MCP_READ_ONLY = "true" }
+```
 
 ---
 
@@ -353,7 +347,7 @@ For production use, you should create a dedicated database user with minimal pri
 ```json
 {
   "mcpServers": {
-    "MariaDB_Server": {
+    "mariadb-mcp": {
       "command": "uvx",
       "args": [
         "mariadb-mcp"
@@ -472,3 +466,18 @@ When creating the **PyPI** Trusted Publisher, use the same values but set the en
 The workflow builds both wheel and source distributions, then:
 - Publishes to **TestPyPI** for pre-releases (or manual dispatch).
 - Publishes to **PyPI** for non-pre-release releases.
+
+## TestPyPI debug install for Codex
+
+```bash
+codex mcp add mariadb-mcp --env DB_HOST=localhost --env DB_PORT=3306 --env DB_USER=root --env DB_PASSWORD=1234 --env DB_NAME=mytestdb --env MCP_READ_ONLY=true -- uvx --index https://test.pypi.org/simple/ --index https://pypi.org/simple/ --index-strategy unsafe-best-match mariadb-mcp
+```
+
+Example Codex config for debug (`codex mcp add` adds servers globally, not just in local `.codex/config.toml`):
+
+```toml
+[mcp_servers.mariadb-mcp]
+command = "uvx"
+args = ["--index", "https://test.pypi.org/simple/", "--index", "https://pypi.org/simple/", "--index-strategy", "unsafe-best-match", "mariadb-mcp"]
+env = { DB_HOST = "localhost", DB_PORT = "3306", DB_USER = "root", DB_PASSWORD = "1234", DB_NAME = "pr0gramm", MCP_READ_ONLY = "true" }
+```

--- a/README.md
+++ b/README.md
@@ -240,15 +240,9 @@ For production use, you should create a dedicated database user with minimal pri
 ### Requirements
 
 - **Python 3.11** (see `.python-version`)
-- **uv** (dependency manager)
+- **uv** (dependency manager; [install instructions](https://github.com/astral-sh/uv))
 - MariaDB server (local or remote)
 
-
-### Install `uv`
-
-```bash
-pip install uv
-```
 
 ### Add MCP to your agent CLI, e.g. Codex
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ For production use, you should create a dedicated database user with minimal pri
 - **uv** (dependency manager)
 - MariaDB server (local or remote)
 
+
 ### Install `uv`
 
 ```bash
@@ -264,16 +265,41 @@ args = ["mariadb-mcp"]
 env = { DB_HOST = "localhost", DB_PORT = "3306", DB_USER = "root", DB_PASSWORD = "1234", DB_NAME = "mytestdb", MCP_READ_ONLY = "true" }
 ```
 
+Or as ``mcp.json``
+```json
+{
+  "mcpServers": {
+    "MariaDB_Server": {
+      "command": "uvx",
+      "args": [
+        "mariadb-mcp"
+        ],
+        "envFile": "path/to/.env"      
+    }
+  }
+}
+```
+
 
 ### Run from a local checkout (development)
 
 ```bash
-# git clone this repo
-# cd /path/to/mariadb-mcp
+git clone https://github.com/VIEWVIEWVIEW/mariadb-mcp
+cd /path/to/mariadb-mcp
 # configure environment variables (see Configuration section above)
 uv lock
 uv sync
-uv run mariadb-mcp
+
+# create .env file in project root
+
+# starts stdio mode
+uv run server.py
+
+# SSE Transport:
+uv run server.py --transport sse --host 127.0.0.1 --port 9001
+
+# HTTP Transport (streamable HTTP):
+uv run server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp
 ```
 
 ---
@@ -431,48 +457,3 @@ uv run mariadb-mcp
 - Tests cover both standard SQL and vector/embedding tool operations.
 
 ---
-
-## Publishing to PyPI (Trusted Publisher / OIDC)
-
-This repository includes a GitHub Actions workflow at `.github/workflows/publish-pypi.yml` that publishes with OpenID Connect (OIDC) using `pypa/gh-action-pypi-publish`.
-
-### Debug release first (TestPyPI)
-
-Create a **pre-release** on GitHub to publish a debug build to TestPyPI.
-
-When creating the **TestPyPI** Trusted Publisher, use:
-
-- **PyPI Project Name:** `mariadb-mcp`
-- **Owner:** `VIEWVIEWVIEW`
-- **Repository name:** `mariadb-mcp`
-- **Workflow name:** `publish-pypi.yml`
-- **Environment name (optional but recommended):** `testpypi`
-
-### Stable release (PyPI)
-
-When creating the **PyPI** Trusted Publisher, use the same values but set the environment to `pypi`:
-
-- **PyPI Project Name:** `mariadb-mcp`
-- **Owner:** `VIEWVIEWVIEW`
-- **Repository name:** `mariadb-mcp`
-- **Workflow name:** `publish-pypi.yml`
-- **Environment name (optional but recommended):** `pypi`
-
-The workflow builds both wheel and source distributions, then:
-- Publishes to **TestPyPI** for pre-releases (or manual dispatch).
-- Publishes to **PyPI** for non-pre-release releases.
-
-## TestPyPI debug install for Codex
-
-```bash
-codex mcp add mariadb-mcp --env DB_HOST=localhost --env DB_PORT=3306 --env DB_USER=root --env DB_PASSWORD=1234 --env DB_NAME=mytestdb --env MCP_READ_ONLY=true -- uvx --index https://test.pypi.org/simple/ --index https://pypi.org/simple/ --index-strategy unsafe-best-match mariadb-mcp
-```
-
-Example Codex config for debug (`codex mcp add` adds servers globally, not just in local `.codex/config.toml`):
-
-```toml
-[mcp_servers.mariadb-mcp]
-command = "uvx"
-args = ["--index", "https://test.pypi.org/simple/", "--index", "https://pypi.org/simple/", "--index-strategy", "unsafe-best-match", "mariadb-mcp"]
-env = { DB_HOST = "localhost", DB_PORT = "3306", DB_USER = "root", DB_PASSWORD = "1234", DB_NAME = "pr0gramm", MCP_READ_ONLY = "true" }
-```

--- a/README.md
+++ b/README.md
@@ -245,12 +245,21 @@ For production use, you should create a dedicated database user with minimal pri
 
 ### Steps
 
-1. **Clone the repository**
-2. **Install `uv`** (if not already):
+1. **Install `uv`** (if not already):
    ```bash
    pip install uv
    ```
-3. **Install dependencies**
+2. **Install from PyPI (recommended)**
+   ```bash
+   uv tool install mariadb-mcp
+   ```
+   Or run it without installing:
+   ```bash
+   uvx mariadb-mcp
+   ```
+3. **Alternative: local development from source**
+   - Clone the repository
+   - Install dependencies
    ```bash
    uv lock
    uv sync
@@ -260,17 +269,22 @@ For production use, you should create a dedicated database user with minimal pri
    
    **Standard Input/Output (default):**
    ```bash
-   uv run server.py
+   mariadb-mcp
    ```
    
    **SSE Transport:**
    ```bash
-   uv run server.py --transport sse --host 127.0.0.1 --port 9001
+   mariadb-mcp --transport sse --host 127.0.0.1 --port 9001
    ```
    
    **HTTP Transport (streamable HTTP):**
    ```bash
-   uv run server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp
+   mariadb-mcp --transport http --host 127.0.0.1 --port 9001 --path /mcp
+   ```
+
+   **Local source checkout (without installation):**
+   ```bash
+   uv run server.py
    ```
 
 ---
@@ -340,12 +354,9 @@ For production use, you should create a dedicated database user with minimal pri
 {
   "mcpServers": {
     "MariaDB_Server": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "--directory",
-        "path/to/mariadb-mcp-server/",
-        "run",
-        "server.py"
+        "mariadb-mcp"
         ],
         "envFile": "path/to/mcp-server-mariadb-vector/.env"      
     }
@@ -429,3 +440,35 @@ For production use, you should create a dedicated database user with minimal pri
 - Tests are located in the `src/tests/` directory.
 - See `src/tests/README.md` for an overview.
 - Tests cover both standard SQL and vector/embedding tool operations.
+
+---
+
+## Publishing to PyPI (Trusted Publisher / OIDC)
+
+This repository includes a GitHub Actions workflow at `.github/workflows/publish-pypi.yml` that publishes with OpenID Connect (OIDC) using `pypa/gh-action-pypi-publish`.
+
+### Debug release first (TestPyPI)
+
+Create a **pre-release** on GitHub to publish a debug build to TestPyPI.
+
+When creating the **TestPyPI** Trusted Publisher, use:
+
+- **PyPI Project Name:** `mariadb-mcp`
+- **Owner:** `VIEWVIEWVIEW`
+- **Repository name:** `mariadb-mcp`
+- **Workflow name:** `publish-pypi.yml`
+- **Environment name (optional but recommended):** `testpypi`
+
+### Stable release (PyPI)
+
+When creating the **PyPI** Trusted Publisher, use the same values but set the environment to `pypi`:
+
+- **PyPI Project Name:** `mariadb-mcp`
+- **Owner:** `VIEWVIEWVIEW`
+- **Repository name:** `mariadb-mcp`
+- **Workflow name:** `publish-pypi.yml`
+- **Environment name (optional but recommended):** `pypi`
+
+The workflow builds both wheel and source distributions, then:
+- Publishes to **TestPyPI** for pre-releases (or manual dispatch).
+- Publishes to **PyPI** for non-pre-release releases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mariadb-mcp"
-version = "0.2.6.dev0"
+version = "0.2.5"
 description = "MariaDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
-name = "mariadb-server"
-version = "0.2.4"
+name = "mariadb-mcp"
+version = "0.2.6.dev0"
 description = "MariaDB MCP Server"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -13,3 +17,10 @@ dependencies = [
     "sentence-transformers>=4.1.0",
     "tokenizers==0.21.2",
 ]
+
+[project.scripts]
+mariadb-mcp = "server:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+py-modules = ["server", "config", "custom_connection", "embeddings", "main"]

--- a/src/server.py
+++ b/src/server.py
@@ -1009,7 +1009,7 @@ class MariaDBServer:
 
 
 # --- Main Execution Block ---
-if __name__ == "__main__":
+def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="MariaDB MCP Server")
     parser.add_argument('--transport', type=str, default='stdio', choices=['stdio', 'sse', 'http'],
                         help='MCP transport protocol (stdio, sse, or http)')
@@ -1019,7 +1019,7 @@ if __name__ == "__main__":
                         help='Port for SSE or HTTP transport')
     parser.add_argument('--path', type=str, default='/mcp',
                         help='Path for HTTP transport (default: /mcp)')
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # 1. Create the server instance
     server = MariaDBServer()
@@ -1043,3 +1043,9 @@ if __name__ == "__main__":
          exit_code = 1
     finally:
         logger.info(f"Server exiting with code {exit_code}.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Please see https://github.com/MariaDB/mcp/issues/53

This PR does the following things:

- [x] rename the package from "mariadb-server" to "mariadb-mcp". Mariadb-server is not what this thing is, and I think "mariadb-mcp" would be more in line with current naming conventions of MCPs.  https://github.com/MariaDB/mcp/blob/3c533f636c1a0c7459992256cde2f3ee70362bc2/pyproject.toml#L2
- [x] Add console entry point in ``pyproject.toml``, so you can simply run ``uvx mariadb-mcp``. Ex.: https://github.com/VIEWVIEWVIEW/mariadb-mcp/blob/afb3f2a9df70704d070e97b21b1eb85b1dc6ae29/pyproject.toml#L21-L22
- [x] Add setuptools config to ``pyproject.toml``, require for PyPi publish job Ex.: https://github.com/VIEWVIEWVIEW/mariadb-mcp/blob/afb3f2a9df70704d070e97b21b1eb85b1dc6ae29/pyproject.toml#L21-L26
- [ ] Setup project on a PyPi account and "trusted publisher" (https://docs.pypi.org/trusted-publishers/adding-a-publisher/) **(Needs to be done by the maintainers, please)**
- [x] Setup a Github action for publishing on PyPi. Ex.: https://github.com/VIEWVIEWVIEW/mariadb-mcp/blob/main/.github/workflows/publish-pypi.yml
- [x] Change README to prefer ``uvx mariadb-mcp``
- [x] Push version number in ``pyproject.toml``