### PR TITLE
Pin docker-compose MCP build to linux/amd64

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,12 @@ For production use, you should create a dedicated database user with minimal pri
    uv run server.py --transport http --host 127.0.0.1 --port 9001 --path /mcp
    ```
 
+### Docker Compose
+
+```bash
+docker compose up --build
+```
+
 ---
 
 ## Usage Examples

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,13 @@ services:
       timeout: 3s
       retries: 10
   mariadb-mcp:
-    build: .
+    # asyncmy wheels crash with SIGILL on native arm64 Docker (Apple Silicon).
+    # Build and run as linux/amd64 only.
+    platform: linux/amd64
+    build:
+      context: .
+      platforms:
+        - linux/amd64
     container_name: mariadb-mcp
     env_file: .env
     ports:


### PR DESCRIPTION
asyncmy fails with SIGILL on native arm64 Docker builds (Apple Silicon). Always build amd64 images and document the limitation.